### PR TITLE
Add metrics

### DIFF
--- a/employees/pom.xml
+++ b/employees/pom.xml
@@ -12,6 +12,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <version.mysql>5.1.38</version.mysql>
+        <version.prometheus>0.0.26</version.prometheus>
         <docker.repo>arungupta</docker.repo>
     </properties>
 
@@ -52,6 +53,21 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${version.mysql}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${version.prometheus}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_servlet</artifactId>
+            <version>${version.prometheus}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>${version.prometheus}</version>
         </dependency>
     </dependencies>
     

--- a/employees/src/main/java/org/javaee/samples/employees/MyApplication.java
+++ b/employees/src/main/java/org/javaee/samples/employees/MyApplication.java
@@ -3,10 +3,14 @@ package org.javaee.samples.employees;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
+import static org.javaee.samples.employees.MyApplication.APP_ROOT;
+
 /**
  * @author arungupta
  */
-@ApplicationPath("resources")
+@ApplicationPath(APP_ROOT)
 public class MyApplication extends Application {
+
+  public static final String APP_ROOT = "/resources";
     
 }

--- a/employees/src/main/java/org/javaee/samples/employees/metrics/MetricsFilter.java
+++ b/employees/src/main/java/org/javaee/samples/employees/metrics/MetricsFilter.java
@@ -1,0 +1,26 @@
+package org.javaee.samples.employees.metrics;
+
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.annotation.WebInitParam;
+
+import static org.javaee.samples.employees.MyApplication.APP_ROOT;
+
+/**
+ * A servlet filter that gathers time to process each request.
+ *
+ * This filter is unaware if two requests are to be routed to the same JAX-RS route,
+ * so requests to /employees/1 and /employees/2 will end up generating separate metrics.
+ *
+ * @author Michael Irwin
+ */
+@WebFilter(
+    filterName = "metrics-filter",
+    urlPatterns = APP_ROOT + "/*",
+    initParams = {
+        @WebInitParam(name = "metric-name", value = "app_metrics"),
+        @WebInitParam(name = "path-components", value = "0")
+    }
+)
+public class MetricsFilter extends io.prometheus.client.filter.MetricsFilter {
+
+}

--- a/employees/src/main/java/org/javaee/samples/employees/metrics/MetricsInitializer.java
+++ b/employees/src/main/java/org/javaee/samples/employees/metrics/MetricsInitializer.java
@@ -1,0 +1,27 @@
+package org.javaee.samples.employees.metrics;
+
+import io.prometheus.client.hotspot.DefaultExports;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+/**
+ * A {@link ServletContextListener} that enables default metric gathering.
+ *
+ * @author Michael Irwin
+ */
+@WebListener
+public class MetricsInitializer implements ServletContextListener {
+
+
+  @Override
+  public void contextInitialized(ServletContextEvent servletContextEvent) {
+    DefaultExports.initialize();
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent servletContextEvent) {
+    // Nothing to do
+  }
+}

--- a/employees/src/main/java/org/javaee/samples/employees/metrics/MetricsServlet.java
+++ b/employees/src/main/java/org/javaee/samples/employees/metrics/MetricsServlet.java
@@ -1,0 +1,13 @@
+package org.javaee.samples.employees.metrics;
+
+import javax.servlet.annotation.WebServlet;
+
+/**
+ * Register the Prometheus Metrics Servlet.
+ *
+ * @author Michael Irwin
+ */
+@WebServlet("/metrics")
+public class MetricsServlet extends io.prometheus.client.exporter.MetricsServlet {
+
+}


### PR DESCRIPTION
Things in this PR:
- Added a Servlet that provides metrics (found at `/metrics`)
- Added a ServletContextListener to enable default metric collection (JVM stats, etc.)
- Added a ServletFilter that collects request/response times

The request-based metrics are currently non-optimal because they don't know that a request for `/employees/1` and `/employees/2` are actually the same request with different parameters.  Ideally, there would be a single metric for `/employees/{id}`, but I was unable to figure out how to get enough context in a JAX-RS filter to do get the non-parameter-replaced path.  Sure, it could be done with more work (build our own metadata store that has paths to matched resources, which is available), but figured this would do well enough for a demo.